### PR TITLE
Add packageSourceCredentials in nuget.config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,7 @@ on:
     branches: [ "master" ]
   schedule:
     - cron: '36 0 * * 2'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,6 +35,10 @@ jobs:
         language: [ 'csharp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+    #These env vars are used in NuGet.config: https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#packagesourcecredentials
+    env:
+      NUGET_USER: ado-doesnt-matter-uses-pat
+      NUGET_TOKEN: ${{ secrets.VULNA_FELICKZ2_FEED }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,6 +23,10 @@ jobs:
         dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
+      #These env vars are used in NuGet.config: https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#packagesourcecredentials
+      env:
+          NUGET_USER: ado-doesnt-matter-uses-pat
+          NUGET_TOKEN: ${{ secrets.VULNA_FELICKZ2_FEED }}
     - name: Build
       run: dotnet build --no-restore
     - name: Test

--- a/.github/workflows/os-dotnet-test.yml
+++ b/.github/workflows/os-dotnet-test.yml
@@ -53,5 +53,6 @@ jobs:
           
       - if: matrix.os == 'windows-latest'
         name: Check NuGet Version On Windows
+        continue-on-error: true
         shell: powershell
-        run: nuget help | select -First 1
+        run: Invoke-Command -ScriptBlock {nuget help} | Select -First 1

--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,6 @@
 	</packageSources>
 	<packageSourceCredentials>
 	    <felickz2>
-		<!-- Username doesnt matter - only password is needed -->
 		<add key="Username" value="%NUGET_USER%" />
 		<add key="ClearTextPassword" value="%NUGET_TOKEN%" />
 	    </felickz2>

--- a/nuget.config
+++ b/nuget.config
@@ -6,6 +6,7 @@
 	</packageSources>
 	<packageSourceCredentials>
 	    <felickz2>
+		<!-- Username doesnt matter - only password is needed -->
 		<add key="Username" value="%NUGET_USER%" />
 		<add key="ClearTextPassword" value="%NUGET_TOKEN%" />
 	    </felickz2>

--- a/nuget.config
+++ b/nuget.config
@@ -4,4 +4,10 @@
 		<clear />
 		<add key="felickz2" value="https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json" />
 	</packageSources>
+	<packageSourceCredentials>
+	    <felickz2>
+		<add key="Username" value="%NUGET_USER%" />
+		<add key="ClearTextPassword" value="%NUGET_TOKEN%" />
+	    </felickz2>
+	</packageSourceCredentials>
 </configuration>


### PR DESCRIPTION
Ex setting NuGet.config 

 [environment variables](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables)

```yml
    env:
      NUGET_USER: ado-doesnt-matter-uses-pat
      NUGET_TOKEN: ${{ secrets.VULNA_FELICKZ2_FEED }}
```

[packagesourcecredentials](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#packagesourcecredentials)
- using a private ADO registry: https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json"

```xml
	<packageSources>
		<clear />
		<add key="felickz2" value="https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json" />
	</packageSources>
	<packageSourceCredentials>
	    <felickz2>
		<add key="Username" value="%NUGET_USER%" />
		<add key="ClearTextPassword" value="%NUGET_TOKEN%" />
	    </felickz2>
	</packageSourceCredentials>
```

# error NU1301: Unable to load the service index for source 
Fix: 
- [x] set feed PAT token in secrets with Package Read access


## Behavior: 6 hour default timeout hit `The operation was canceled.`

```
2024-01-08T17:51:18.6508680Z Running nuget restore /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI.sln -DisableParallelProcessing
2024-01-08T17:51:19.9241577Z MSBuild auto-detection: using msbuild version '15.0' from '/usr/lib/mono/msbuild/15.0/bin'.
2024-01-08T17:51:22.8400936Z Restoring packages for /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI.csproj...
2024-01-08T17:51:23.1845825Z Using credentials from config. UserName: ado-doesnt-matter-uses-pat
2024-01-08T17:51:23.2278618Z Please provide credentials for: https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json
2024-01-08T18:01:28.4117894Z NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json.
2024-01-08T18:11:34.1894171Z NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json.
2024-01-08T18:11:34.2522974Z UserName: Generating MSBuild file /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/obj/DotNetCoreWebAPI.csproj.nuget.g.props.
2024-01-08T18:11:34.2539002Z Generating MSBuild file /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/obj/DotNetCoreWebAPI.csproj.nuget.g.targets.
2024-01-08T18:11:34.2541945Z Writing assets file to disk. Path: /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/obj/project.assets.json
2024-01-08T18:11:34.2708151Z Failed to restore /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI.csproj (in 20.19 min).
2024-01-08T18:11:34.2741734Z 
2024-01-08T18:11:34.2745070Z Errors in /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI/DotNetCoreWebAPI.csproj
2024-01-08T18:11:34.2751228Z     NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json.
2024-01-08T18:11:34.2753530Z     NU1301: Unable to load the service index for source https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json.
2024-01-08T18:11:34.2754699Z 
2024-01-08T18:11:34.2754889Z NuGet Config files used:
2024-01-08T18:11:34.2755641Z     /home/runner/work/DotNetCoreWebAPI/DotNetCoreWebAPI/nuget.config
2024-01-08T18:11:34.2756523Z     /home/runner/.config/NuGet/NuGet.Config
2024-01-08T18:11:34.2756967Z 
2024-01-08T18:11:34.2757112Z Feeds used:
2024-01-08T18:11:34.2757815Z     https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json
2024-01-08T23:50:22.3562751Z ##[error]The operation was canceled.
2024-01-08T23:50:22.3630233Z Post job cleanup.
```