### PR TITLE
Easier CSharp Scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,22 +54,11 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '36 0 * * 2'
 
+env:
+  CODEQL_EXTRACTOR_CSHARP_OPTION_BUILDLESS: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
This pull request includes a small but significant change to the `CODEQL_EXTRACTOR_CSHARP_OPTION_BUILDLESS` environment variable in the `.github/workflows/codeql-analysis.yml` file. The change sets the environment variable to `true`, which should help improve the efficiency of the CodeQL analysis workflow.


## Observations
- 2024-01-08T17:47:24.2833973Z CodeQL scanned 2 out of 4 C# files in this job.

| Configuration                                                 | Language | File Path                                                 | Successfully Extracted |   |
|---------------------------------------------------------------|----------|-----------------------------------------------------------|------------------------|---|
| .github/workflows/codeql-analysis.yml:analyze/language:csharp | C#       | DotNetCoreWebAPI/Controllers/WeatherForecastController.cs | TRUE                   |   |
| .github/workflows/codeql-analysis.yml:analyze/language:csharp | C#       | DotNetCoreWebAPI/WeatherForecast.cs                       | TRUE                   |   |
| .github/workflows/codeql-analysis.yml:analyze/language:csharp | C#       | DotNetCoreWebAPI/Program.cs                               | FALSE                  |   |
| .github/workflows/codeql-analysis.yml:analyze/language:csharp | C#       | DotNetCoreWebAPI/Models/WeatherForeCastInputModel.cs      | FALSE                  |   |

- Build summary
```
2024-01-08T17:46:31.6913563Z [001] Build analysis summary:
2024-01-08T17:46:31.6913876Z [001]      5 source files in the filesystem
2024-01-08T17:46:31.6914243Z [001]      4 source files in project files
2024-01-08T17:46:31.6914619Z [001]      0 sources missing from project files
2024-01-08T17:46:31.6915039Z [001]    301 resolved references
2024-01-08T17:46:31.6915338Z [001]      0 unresolved references
2024-01-08T17:46:31.6915661Z [001]      0 resolved assembly conflicts
2024-01-08T17:46:31.6915969Z [001]      1 projects
2024-01-08T17:46:31.6916226Z [001]      0 missing/failed projects
2024-01-08T17:46:31.6916587Z [001] Build analysis completed in 00:01:07.4282636
```

- All resolved references are net core 8 .. `Microsoft.NETCore.App.Ref/8.0.0/` .. the application is:  [<TargetFramework>net6.0</TargetFramework>](https://github.com/vulna-felickz/DotNetCoreWebAPI/blob/acc7cbb1cc3b742f50ea8188d3c9d622fdfc0e38/DotNetCoreWebAPI/DotNetCoreWebAPI.csproj#L4C5-L4C46)
- Still attempts to connect to custom nuget feed: `error : Unable to load the service index for source https://pkgs.dev.azure.com/felickz2/_packaging/felickz2/nuget/v3/index.json`
- Seeing 4 instances of `BUILD FAILED.`
  -  .sln
  - .csproj
  - /tmp/GitHub/packages/338826848c7764ab/338826848c7764ab.csproj
  - /tmp/GitHub/packages/69a90d7ce7c134f9/69a90d7ce7c134f9.csproj